### PR TITLE
fix: updated repository test

### DIFF
--- a/src/test/java/com/techreturners/bookmanager/repository/BookManagerRepositoryTests.java
+++ b/src/test/java/com/techreturners/bookmanager/repository/BookManagerRepositoryTests.java
@@ -29,7 +29,7 @@ public class BookManagerRepositoryTests {
     @Test
     public void testCreatesAndFindBookByIdReturnsBook() {
 
-        Book book = new Book(2L, "Book Two", "This is the description for Book Two", "Person Two", Genre.Fantasy);
+        Book book = new Book(1L, "Book Two", "This is the description for Book Two", "Person Two", Genre.Fantasy);
         bookManagerRepository.save(book);
 
         var bookById = bookManagerRepository.findById(book.getId());


### PR DESCRIPTION
testCreatesAndFindBookByIdReturnsBook test returned an Optional.empty due to an auto generated ID of 1 (the test used an ID of 2 in the instantiated object). Amended this ID to 1. Test operates as it should now